### PR TITLE
Adds flags to the comment  Record

### DIFF
--- a/packages/frontend-web/src/models/comment.ts
+++ b/packages/frontend-web/src/models/comment.ts
@@ -89,6 +89,7 @@ const CommentModelRecord = Record({
   article: null,
   replies: null,
   commentScores: null,
+  commentFlags: null,
   maxSummaryScore: null,
   maxSummaryScoreTagId: null,
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When flags relationship is enabled on the NYT comments api backend Moderator fails to populate payloads into the comment model due to not having a commentFlags attribute in the Comment Record
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.