### PR TITLE
NYT performance fixes

### DIFF
--- a/packages/frontend-web/src/app/main.tsx
+++ b/packages/frontend-web/src/app/main.tsx
@@ -52,7 +52,8 @@ const store = createStore(
   Immutable.Map(),
   compose(
     applyMiddleware(thunk),
-    (window as any)['devToolsExtension'] ? (window as any)['devToolsExtension']() : (f: any) => f,
+    // TODO: Make this toggle based on environment
+    //(window as any)['devToolsExtension'] ? (window as any)['devToolsExtension']() : (f: any) => f,    
   ),
 );
 

--- a/packages/frontend-web/src/app/platform/websocketService.ts
+++ b/packages/frontend-web/src/app/platform/websocketService.ts
@@ -69,8 +69,8 @@ export interface IAllArticlesData {
 }
 
 export interface IArticleUpdate {
-  category?: ICategoryModel;
-  article: IArticleModel;
+  categories?: List<ICategoryModel>;
+  articles?: List<IArticleModel>;
 }
 
 export interface IPerUserData {
@@ -123,25 +123,26 @@ function packArticleData(data: any): IAllArticlesData {
 }
 
 function packArticleUpdate(data: any): IArticleUpdate {
-  const cdata = data.category;
-  let cmodel;
-  let amodel;
-
-  if (cdata) {
-    cdata.id = cdata.id.toString();
-    cmodel = CategoryModel(cdata);
+  let categories;
+  let articles;
+  if(data.categories) {
+    categories = List<ICategoryModel>(data.categories.map((c: any) => {
+      c.id = c.id.toString();
+      return CategoryModel(c);
+    }));
   }
 
-  const adata = data.article;
-  if (adata) {
-    adata.id = adata.id.toString();
-    adata.categoryId = adata.categoryId && adata.categoryId.toString();
-    amodel = ArticleModel(adata);
+  if(data.articles) {
+    articles = List<IArticleModel>(data.articles.map((a: any) => {
+      a.id = a.id.toString();
+      a.categoryId = a.categoryId && a.categoryId.toString();
+      return ArticleModel(a);
+    }));
   }
 
   return {
-    category: cmodel,
-    article: amodel,
+    categories: categories,
+    articles: articles,
   };
 }
 

--- a/packages/frontend-web/src/app/platform/websocketService.ts
+++ b/packages/frontend-web/src/app/platform/websocketService.ts
@@ -125,11 +125,17 @@ function packArticleData(data: any): IAllArticlesData {
 function packArticleUpdate(data: any): IArticleUpdate {
   let categories;
   let articles;
+ 
+  
   if(data.categories) {
     categories = List<ICategoryModel>(data.categories.map((c: any) => {
       c.id = c.id.toString();
       return CategoryModel(c);
     }));
+  } else if(data.category) { // Backwards compatibility with single category
+      const cdata = data.category;
+      cdata.id = cdata.id.toString();
+      categories = List<ICategoryModel>([CategoryModel(cdata)]);
   }
 
   if(data.articles) {
@@ -138,6 +144,11 @@ function packArticleUpdate(data: any): IArticleUpdate {
       a.categoryId = a.categoryId && a.categoryId.toString();
       return ArticleModel(a);
     }));
+  } else if (data.article) { // Backwards compatibility with single article
+    const adata = data.article;
+    adata.id = adata.id.toString();
+    adata.categoryId = adata.categoryId && adata.categoryId.toString();
+    articles = List<IArticleModel>([ArticleModel(adata)]);
   }
 
   return {

--- a/packages/frontend-web/src/app/stores/articles.ts
+++ b/packages/frontend-web/src/app/stores/articles.ts
@@ -25,7 +25,7 @@ const STATE_ROOT = ['global', 'articles'];
 const INDEX = [...STATE_ROOT, 'index'];
 
 export const articlesLoaded = createAction<List<IArticleModel>>('global/ARTICLES_LOADED');
-export const articleUpdated = createAction<IArticleModel>('global/ARTICLE_UPDATED');
+export const articleUpdated = createAction<List<IArticleModel>>('global/ARTICLE_UPDATED');
 
 export function getArticles(state: IAppStateRecord): Map<ModelId, IArticleModel> {
   return state.getIn(INDEX);
@@ -50,8 +50,8 @@ const reducer = handleActions<IArticlesStateRecord, List<IArticleModel>| IArticl
     const index = Map<ModelId, IArticleModel>(payload.map((v) => ([v.id, v])));
     return state.set('index', index);
   },
-  [articleUpdated.toString()]: (state: IArticlesStateRecord, { payload }: Action<IArticleModel>) => {
-    return state.set('index', state.get('index').set(payload.id, payload));
+  [articleUpdated.toString()]: (state: IArticlesStateRecord, { payload }: Action<List<IArticleModel>>) => {
+    return state.set('index', state.get('index').merge(payload.map((v) => ([v.id, v]))));
   },
 }, StateFactory());
 

--- a/packages/frontend-web/src/app/stores/categories.ts
+++ b/packages/frontend-web/src/app/stores/categories.ts
@@ -24,7 +24,7 @@ const STATE_ROOT = ['global', 'categories'];
 const INDEX = [...STATE_ROOT, 'index'];
 
 export const categoriesLoaded = createAction<List<ICategoryModel>>('global/CATEGORIES_LOADED');
-export const categoryUpdated = createAction<ICategoryModel>('global/CATEGORY_UPDATED');
+export const categoryUpdated = createAction<List<ICategoryModel>>('global/CATEGORY_UPDATED');
 
 export function getCategoryMap(state: IAppStateRecord): Map<ModelId, ICategoryModel> {
   return state.getIn(INDEX);
@@ -90,7 +90,7 @@ export const reducer = handleActions<ICategoriesStateRecord, List<ICategoryModel
     const index = Map<ModelId, ICategoryModel>(payload.map((v) => ([v.id, v])));
     return state.set('index', index);
   },
-  [categoryUpdated.toString()]: (state: ICategoriesStateRecord, { payload }: Action<ICategoryModel>) => {
-    return state.set('index', state.get('index').set(payload.id, payload));
+  [categoryUpdated.toString()]: (state: ICategoriesStateRecord, { payload }: Action<List<ICategoryModel>>) => {
+    return state.set('index', state.get('index').merge(payload.map((v) => ([v.id, v]))));
   },
 }, CategoriesStateFactory());

--- a/packages/frontend-web/src/app/stores/index.ts
+++ b/packages/frontend-web/src/app/stores/index.ts
@@ -139,11 +139,11 @@ export async function initialiseClientModel(dispatch: IAppDispatch) {
       dispatch(articlesLoaded(data.articles));
     },
     (data) => {
-      if (data.category) {
-        dispatch(categoryUpdated(data.category));
+      if (data.categories) {
+        dispatch(categoryUpdated(data.categories));
       }
-      if (data.article) {
-        dispatch(articleUpdated(data.article));
+      if (data.articles) {
+        dispatch(articleUpdated(data.articles));
       }
     },
     (data) => {

--- a/packages/frontend-web/src/test/notificationChecks.ts
+++ b/packages/frontend-web/src/test/notificationChecks.ts
@@ -67,8 +67,9 @@ class ArticleMessages {
   @autobind
   updateHandler(data: IArticleUpdate) {
     console.log('+ Received singe article update message');
-    checkCategory(data.category);
-    checkArticle(data.article);
+    data.categories.forEach(c => checkCategory(c));
+    data.articles.forEach(a => checkArticle(a));
+   
     if (this.updateHappened) {
       this.updateHappened('article-update', data);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This changes allows us to batch article updates into a single state change.  Previously we were splitting all updates occuring every second from the NYT backend into separate messages.  This was overwhelming the front end.  By enabling batched updates the state updates at a fixed rate (since we poll updates).  

Local tests compared to previous implementation showed that this was enough to stop the memory consumption from growing while sitting idly on the dashboard.  After about 15-20 minutes the the build currently in production had built up to around 450 mb of memory usage while the local build stayed at around 150 mb the entire time.  Additionally while the cpu spikes to around 20-30 % usage every time we send a batched packet in, it drops to around 0% in between whereas the previous build sits at a more constant 8-20% usage with occasional spikes to higher amounts.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.